### PR TITLE
Move config to postinstall

### DIFF
--- a/vpn-admin-portal/debian/install
+++ b/vpn-admin-portal/debian/install
@@ -1,7 +1,7 @@
 #!/usr/bin/dh-exec --with=install
 
 debian/apache.conf => /etc/apache2/conf-available/vpn-admin-portal.conf
-config/config.php.example => /etc/vpn-admin-portal/default/config.php
+config/config.php.example => /usr/share/doc/vpn-admin-portal/config.php.example
 
 bin/add-user.php => /usr/bin/vpn-admin-portal-add-user
 

--- a/vpn-admin-portal/debian/postinst
+++ b/vpn-admin-portal/debian/postinst
@@ -13,6 +13,33 @@ case "$1" in
     configure)
         chown www-data:www-data /var/lib/vpn-admin-portal
         chmod 700 /var/lib/vpn-admin-portal
+
+	if [ ! -d /etc/vpn-admin-portal/ ]; then
+		install -d -m 750 /etc/vpn-admin-portal
+	fi
+
+	# Make sure ownership is allright
+	chown -R root:www-data /etc/vpn-admin-portal
+	chmod 750 /etc/vpn-admin-portal
+
+	# Check if we are upgrading, the upgrade
+	# file is written by preinst upgrade
+	if [ -f /etc/vpn-admin-portal/.upgrade ]; then
+		echo "Upgrade, not touching configuration"
+		rm  /etc/vpn-admin-portal/.upgrade
+	else
+		# This is a new installation. Try to create default config
+		if [ ! -d /etc/vpn-admin-portal/default ]; then
+			echo "New installation, creating default configuration"
+			install -d -m 755 /etc/vpn-admin-portal/default
+			install -m 644 /usr/share/doc/vpn-admin-portal/config.php.example \
+				       /etc/vpn-admin-portal/default/config.php
+		else
+			echo "New installation, but existing default configuration found. Not updating"
+		fi
+	fi
+
+
     ;;
 
     abort-upgrade|abort-remove|abort-deconfigure)

--- a/vpn-admin-portal/debian/preinst
+++ b/vpn-admin-portal/debian/preinst
@@ -1,0 +1,21 @@
+#!/bin/sh
+# preinst script for vpn-admin-portal
+#
+# see: dh_installdeb(1)
+
+set -e
+
+if [ -f /usr/share/debconf/confmodule ]; then
+        . /usr/share/debconf/confmodule
+fi
+
+case "$1" in
+    upgrade)
+	# Mark upgrade    
+        touch /etc/vpn-admin-portal/.upgrade
+    ;;
+    
+esac
+
+
+exit 0

--- a/vpn-admin-portal/debian/rules
+++ b/vpn-admin-portal/debian/rules
@@ -17,5 +17,8 @@ override_dh_auto_test:
 	echo "require_once 'src/autoload.php';" >> tests/autoload.php
 	phpunit --bootstrap=tests/autoload.php
 
+# Be sure not to compress
+override_dh_compress:
+
 %:
 	dh $@ --with phpcomposer

--- a/vpn-server-api/debian/install
+++ b/vpn-server-api/debian/install
@@ -1,7 +1,7 @@
 #!/usr/bin/dh-exec --with=install
 
 debian/apache.conf => /etc/apache2/conf-available/vpn-server-api.conf
-config/config.php.example => /etc/vpn-server-api/default/config.php
+config/config.php.example => /usr/share/doc/vpn-server-api/config.php.example
 
 src/* /usr/share/php/SURFnet/VPN/Server/
 web /usr/share/vpn-server-api/

--- a/vpn-server-api/debian/postinst
+++ b/vpn-server-api/debian/postinst
@@ -13,6 +13,31 @@ case "$1" in
     configure)
         chown www-data:www-data /var/lib/vpn-server-api
         chmod 700 /var/lib/vpn-server-api
+
+	if [ ! -d /etc/vpn-server-api/ ]; then
+		install -d -m 750 /etc/vpn-server-api
+	fi
+
+	# Make sure ownership is allright
+	chown -R root:www-data /etc/vpn-server-api
+	chmod 750 /etc/vpn-server-api
+
+	# Check if we are upgrading, the upgrade
+	# file is written by preinst upgrade
+	if [ -f /etc/vpn-server-api/.upgrade ]; then
+		echo "Upgrade, not touching configuration"
+		rm  /etc/vpn-server-api/.upgrade
+	else
+		# This is a new installation. Try to create default config
+		if [ ! -d /etc/vpn-server-api/default ]; then
+			echo "New installation, creating default configuration"
+			install -d -m 755 /etc/vpn-server-api/default
+			install -m 644 /usr/share/doc/vpn-server-api/config.php.example \
+				       /etc/vpn-server-api/default/config.php
+		else
+			echo "New installation, but existing default configuration found. Not updating"
+		fi
+	fi
     ;;
 
     abort-upgrade|abort-remove|abort-deconfigure)

--- a/vpn-server-api/debian/postrm
+++ b/vpn-server-api/debian/postrm
@@ -1,5 +1,5 @@
 #!/bin/sh
-# postrm script for php-saml-ds
+# postrm script for vpn-server-api
 #
 # see: dh_installdeb(1)
 

--- a/vpn-server-api/debian/preinst
+++ b/vpn-server-api/debian/preinst
@@ -1,0 +1,21 @@
+#!/bin/sh
+# preinst script for vpn-server-api
+#
+# see: dh_installdeb(1)
+
+set -e
+
+if [ -f /usr/share/debconf/confmodule ]; then
+        . /usr/share/debconf/confmodule
+fi
+
+case "$1" in
+    upgrade)
+	# Mark upgrade    
+        touch /etc/vpn-server-api/.upgrade
+    ;;
+    
+esac
+
+
+exit 0

--- a/vpn-server-api/debian/rules
+++ b/vpn-server-api/debian/rules
@@ -19,5 +19,8 @@ override_dh_auto_test:
 	echo "require_once 'src/autoload.php';" >> tests/autoload.php
 	phpunit --bootstrap=tests/autoload.php
 
+# Be sure not to compress
+override_dh_compress:
+
 %:
 	dh $@ --with phpcomposer

--- a/vpn-server-node/debian/install
+++ b/vpn-server-node/debian/install
@@ -1,7 +1,7 @@
 #!/usr/bin/dh-exec --with=install
 
-config/config.php.example => /etc/vpn-server-node/default/config.php
-config/firewall.php.example => /etc/vpn-server-node/firewall.php
+config/config.php.example => /usr/share/doc/vpn-server-node/config.php.example
+config/firewall.php.example => /usr/share/doc/vpn-server-node/firewall.php.example
 
 src/* /usr/share/php/SURFnet/VPN/Node/
 

--- a/vpn-server-node/debian/postinst
+++ b/vpn-server-node/debian/postinst
@@ -1,0 +1,61 @@
+#!/bin/sh
+# postinst script for vpn-server-node
+#
+# see: dh_installdeb(1)
+
+set -e
+
+if [ -f /usr/share/debconf/confmodule ]; then
+        . /usr/share/debconf/confmodule
+fi
+
+case "$1" in
+    configure)
+
+	if [ ! -d /etc/vpn-server-node/ ]; then
+		install -d -m 750 /etc/vpn-server-node
+	fi
+
+	# Make sure ownership is allright
+	chown -R root:nogroup /etc/vpn-server-node
+	chmod 750 /etc/vpn-server-node
+
+	# Check if we are upgrading, the upgrade
+	# file is written by preinst upgrade
+	if [ -f /etc/vpn-server-node/.upgrade ]; then
+		echo "Upgrade, not touching configuration"
+		rm  /etc/vpn-server-node/.upgrade
+	else
+		# This is a new installation. Try to create default config
+		if [ ! -d /etc/vpn-server-node/default ]; then
+			echo "New installation, creating default configuration"
+			install -d -m 755 /etc/vpn-server-node/default
+			install -m 644 /usr/share/doc/vpn-server-node/config.php.example \
+				       /etc/vpn-server-node/default/config.php
+		else
+			echo "New installation, but existing default configuration found. Not updating"
+		fi
+
+		# This is a new installation. Try to create default config
+		if [ ! -f /etc/vpn-server-node/firewall.php ]; then
+			echo "New installation, creating firewall configuration"
+			install -d -m 755 /etc/vpn-server-node/default
+			install -m 644 /usr/share/doc/vpn-server-node/firewall.php.example \
+				       /etc/vpn-server-node/firewall.php
+		else
+			echo "New installation, but existing firewall configuration found. Not updating"
+		fi
+
+	fi
+    ;;
+
+    abort-upgrade|abort-remove|abort-deconfigure)
+    ;;
+
+    *)
+        echo "postinst called with unknown argument \`$1'" >&2
+        exit 1
+    ;;
+esac
+
+#DEBHELPER#

--- a/vpn-server-node/debian/preinst
+++ b/vpn-server-node/debian/preinst
@@ -1,0 +1,21 @@
+#!/bin/sh
+# preinst script for vpn-server-node
+#
+# see: dh_installdeb(1)
+
+set -e
+
+if [ -f /usr/share/debconf/confmodule ]; then
+        . /usr/share/debconf/confmodule
+fi
+
+case "$1" in
+    upgrade)
+	# Mark upgrade    
+        touch /etc/vpn-server-node/.upgrade
+    ;;
+    
+esac
+
+
+exit 0

--- a/vpn-server-node/debian/rules
+++ b/vpn-server-node/debian/rules
@@ -21,5 +21,8 @@ override_dh_fixperms:
 	dh_fixperms
 	chmod 0755 debian/vpn-server-node/usr/lib/vpn-server-node/*
 
+# Be sure not to compress
+override_dh_compress:
+
 %:
 	dh $@ --with phpcomposer

--- a/vpn-user-portal/debian/install
+++ b/vpn-user-portal/debian/install
@@ -8,7 +8,7 @@ bin/init.php => /usr/bin/vpn-user-portal-init
 bin/show-public-key.php => /usr/bin/vpn-user-portal-show-public-key
 bin/generate-voucher.php => /usr/bin/vpn-user-portal-generate-voucher
 
-config/config.php.example => /etc/vpn-user-portal/default/config.php
+config/config.php.example => /usr/share/doc/vpn-user-portal/config.php.example
 
 src/* /usr/share/php/SURFnet/VPN/Portal/
 

--- a/vpn-user-portal/debian/postinst
+++ b/vpn-user-portal/debian/postinst
@@ -13,6 +13,33 @@ case "$1" in
     configure)
         chown -R www-data:www-data /var/lib/vpn-user-portal
         chmod -R 700 /var/lib/vpn-user-portal
+
+
+	if [ ! -d /etc/vpn-user-portal/ ]; then
+		install -d -m 750 /etc/vpn-user-portal
+	fi
+
+	# Make sure ownership is allright
+	chown -R root:www-data /etc/vpn-user-portal
+	chmod 750 /etc/vpn-user-portal
+
+	# Check if we are upgrading, the upgrade
+	# file is written by preinst upgrade
+	if [ -f /etc/vpn-user-portal/.upgrade ]; then
+		echo "Upgrade, not touching configuration"
+		rm  /etc/vpn-user-portal/.upgrade
+	else
+		# This is a new installation. Try to create default config
+		if [ ! -d /etc/vpn-user-portal/default ]; then
+			echo "New installation, creating default configuration"
+			install -d -m 755 /etc/vpn-user-portal/default
+			install -m 644 /usr/share/doc/vpn-user-portal/config.php.example \
+				       /etc/vpn-user-portal/default/config.php
+		else
+			echo "New installation, but existing default configuration found. Not updating"
+		fi
+	fi
+
     ;;
 
     abort-upgrade|abort-remove|abort-deconfigure)

--- a/vpn-user-portal/debian/preinst
+++ b/vpn-user-portal/debian/preinst
@@ -1,0 +1,21 @@
+#!/bin/sh
+# preinst script for vpn-user-portal
+#
+# see: dh_installdeb(1)
+
+set -e
+
+if [ -f /usr/share/debconf/confmodule ]; then
+        . /usr/share/debconf/confmodule
+fi
+
+case "$1" in
+    upgrade)
+	# Mark upgrade    
+        touch /etc/vpn-user-portal/.upgrade
+    ;;
+    
+esac
+
+
+exit 0

--- a/vpn-user-portal/debian/rules
+++ b/vpn-user-portal/debian/rules
@@ -20,5 +20,8 @@ override_dh_auto_test:
 	echo "require_once 'src/autoload.php';" >> tests/autoload.php
 	phpunit --bootstrap=tests/autoload.php
 
+# Be sure not to compress
+override_dh_compress:
+
 %:
 	dh $@ --with phpcomposer


### PR DESCRIPTION

- Moved example configs to doc folders.
- Installs default config if no config exists
- Does not update a config on upgrade or reinstall
- Set filesystem rights for /etc/vpn-* folders in postinst