### PR TITLE
fix some lintian warnings  (Issue #17)

### DIFF
--- a/BaconQrCode/debian/changelog
+++ b/BaconQrCode/debian/changelog
@@ -1,3 +1,9 @@
+baconqrcode (1.0.3-4) stable; urgency=medium
+
+  * debian/control: Add myself to Uploaders, similar to other packages in the eduvpn suite.
+
+ -- Joost van Baal-Ilić <joostvb-eduvpn@ad1810.com>  Sun, 28 Oct 2018 10:30:11 +0100
+
 baconqrcode (1.0.3-3) stable; urgency=medium
 
   * fix running PHPUnit tests on newer versions of PHPUnit
@@ -12,10 +18,7 @@ baconqrcode (1.0.3-2) stable; urgency=medium
 
 baconqrcode (1.0.3-1) stable; urgency=medium
 
-  [ Gijs Molenaar ]
   * New upstream version 1.0.3
-
-  [ Gijs Molenaar (launchpad ppa build key) ]
 
  -- Gijs Molenaar (launchpad ppa build key) <gijs@pythonic.nl>  Tue, 24 Oct 2017 07:44:16 +0200
 

--- a/BaconQrCode/debian/control
+++ b/BaconQrCode/debian/control
@@ -2,6 +2,7 @@ Source: baconqrcode
 Section: web
 Priority: optional
 Maintainer: François Kooman <fkooman@tuxed.net>
+Uploaders: Joost van Baal-Ilić <joostvb-eduvpn@ad1810.com>
 Build-Depends: 
  debhelper (>= 9), 
  phpunit, 

--- a/Twig-extensions/debian/changelog
+++ b/Twig-extensions/debian/changelog
@@ -1,3 +1,9 @@
+twig-extensions (1.3.0-6) stable; urgency=medium
+
+  * debian/control: Add myself to Uploaders, similar to other packages in the eduvpn suite.
+
+ -- Joost van Baal-Ilić <joostvb-eduvpn@ad1810.com>  Sun, 28 Oct 2018 10:31:44 +0100
+
 twig-extensions (1.3.0-5) stable; urgency=medium
 
   * cleanup package

--- a/Twig-extensions/debian/control
+++ b/Twig-extensions/debian/control
@@ -2,6 +2,7 @@ Source: twig-extensions
 Section: php
 Priority: optional
 Maintainer: François Kooman <fkooman@tuxed.net>
+Uploaders: Joost van Baal-Ilić <joostvb-eduvpn@ad1810.com>
 Build-Depends: 
  debhelper (>= 9), 
  phpunit, 

--- a/php-json-signer/debian/changelog
+++ b/php-json-signer/debian/changelog
@@ -1,3 +1,10 @@
+php-json-signer (3.0.2-6) stable; urgency=medium
+
+  * debian/control: Add myself to Uploaders, similar to other packages in the
+    eduvpn suite.
+
+ -- Joost van Baal-Ilić <joostvb-eduvpn@ad1810.com>  Tue, 04 Sep 2018 15:41:32 +0200
+
 php-json-signer (3.0.2-5) stable; urgency=medium
 
   * only depend on php-libsodium

--- a/php-json-signer/debian/control
+++ b/php-json-signer/debian/control
@@ -2,6 +2,7 @@ Source: php-json-signer
 Section: php
 Priority: extra
 Maintainer: François Kooman <fkooman@tuxed.net>
+Uploaders: Joost van Baal-Ilić <joostvb-eduvpn@ad1810.com>
 Build-Depends:
  debhelper (>= 9),
  phpab,

--- a/php-oauth2-client/debian/changelog
+++ b/php-oauth2-client/debian/changelog
@@ -1,3 +1,11 @@
+php-oauth2-client (7.1.3-3) stable; urgency=medium
+
+  * debian/control: Add myself to Uploaders, similar to other packages in the
+    eduvpn suite.  This cleans up lintian source warnings:
+    "changelog-should-mention-nmu" and "source-nmu-has-incorrect-version-number".
+
+ -- Joost van Baal-Ilić <joostvb-eduvpn@ad1810.com>  Tue, 04 Sep 2018 15:19:53 +0200
+
 php-oauth2-client (7.1.3-2) stable; urgency=medium
 
   * debian/watch: upstream downloads moved from git.tuxed.net to

--- a/php-oauth2-client/debian/control
+++ b/php-oauth2-client/debian/control
@@ -2,6 +2,7 @@ Source: php-oauth2-client
 Section: php
 Priority: optional
 Maintainer: François Kooman <fkooman@tuxed.net>
+Uploaders: Joost van Baal-Ilić <joostvb-eduvpn@ad1810.com>
 Build-Depends:
  debhelper (>= 9),
  phpunit,

--- a/php-oauth2-server/debian/changelog
+++ b/php-oauth2-server/debian/changelog
@@ -1,3 +1,10 @@
+php-oauth2-server (3.0.2-3) stable; urgency=medium
+
+  * debian/control: Add myself to Uploaders, similar to other packages in the
+    eduvpn suite.
+
+ -- Joost van Baal-Ilić <joostvb-eduvpn@ad1810.com>  Sun, 28 Oct 2018 10:35:46 +0100
+
 php-oauth2-server (3.0.2-2) stable; urgency=medium
 
   * only depend on php-libsodium

--- a/php-oauth2-server/debian/control
+++ b/php-oauth2-server/debian/control
@@ -2,6 +2,7 @@ Source: php-oauth2-server
 Section: php
 Priority: optional
 Maintainer: François Kooman <fkooman@tuxed.net>
+Uploaders: Joost van Baal-Ilić <joostvb-eduvpn@ad1810.com>
 Build-Depends:
  debhelper (>= 9),
  pkg-php-tools,

--- a/php-openvpn-connection-manager/debian/changelog
+++ b/php-openvpn-connection-manager/debian/changelog
@@ -1,3 +1,11 @@
+php-openvpn-connection-manager (1.0.2-3) stable; urgency=medium
+
+  * debian/control: Add myself to Uploaders, similar to other packages in the
+    eduvpn suite.  This cleans up lintian source warnings:
+    "changelog-should-mention-nmu" and "source-nmu-has-incorrect-version-number".
+
+ -- Joost van Baal-Ilić <joostvb-eduvpn@ad1810.com>  Sun, 28 Oct 2018 10:36:16 +0100
+
 php-openvpn-connection-manager (1.0.2-2) stable; urgency=medium
 
   * debian/watch: upstream downloads moved from git.tuxed.net to

--- a/php-openvpn-connection-manager/debian/control
+++ b/php-openvpn-connection-manager/debian/control
@@ -2,6 +2,7 @@ Source: php-openvpn-connection-manager
 Section: php
 Priority: optional
 Maintainer: François Kooman <fkooman@tuxed.net>
+Uploaders: Joost van Baal-Ilić <joostvb-eduvpn@ad1810.com>
 Build-Depends:
  debhelper (>= 9),
  phpunit,

--- a/php-otp-verifier/debian/changelog
+++ b/php-otp-verifier/debian/changelog
@@ -1,3 +1,10 @@
+php-otp-verifier (0.2.1-2) stable; urgency=medium
+
+  * debian/control: Add myself to Uploaders, similar to other packages in the
+    eduvpn suite.
+
+ -- Joost van Baal-Ilić <joostvb-eduvpn@ad1810.com>  Sun, 28 Oct 2018 10:37:13 +0100
+
 php-otp-verifier (0.2.1-1) stable; urgency=medium
 
   * update to 0.2.1

--- a/php-otp-verifier/debian/control
+++ b/php-otp-verifier/debian/control
@@ -2,6 +2,7 @@ Source: php-otp-verifier
 Section: php
 Priority: optional
 Maintainer: François Kooman <fkooman@tuxed.net>
+Uploaders: Joost van Baal-Ilić <joostvb-eduvpn@ad1810.com>
 Build-Depends:
  debhelper (>= 9),
  phpunit,

--- a/php-saml-ds/debian/changelog
+++ b/php-saml-ds/debian/changelog
@@ -1,3 +1,11 @@
+php-saml-ds (1.0.12-3) stable; urgency=medium
+
+  * debian/control: Add myself to Uploaders, similar to other packages in the
+    eduvpn suite.  This cleans up lintian source warnings:
+    "changelog-should-mention-nmu" and "source-nmu-has-incorrect-version-number".
+
+ -- Joost van Baal-Ilić <joostvb-eduvpn@ad1810.com>  Sun, 28 Oct 2018 10:38:00 +0100
+
 php-saml-ds (1.0.12-2) stable; urgency=medium
 
   * debian/watch: upstream downloads moved from git.tuxed.net to
@@ -60,10 +68,7 @@ php-saml-ds (1.0.8-2) stable; urgency=medium
 
 php-saml-ds (1.0.8-1) stable; urgency=medium
 
-  [ Gijs Molenaar ]
   * New upstream version 1.0.8
-
-  [ Gijs Molenaar (launchpad ppa build key) ]
 
  -- Gijs Molenaar (launchpad ppa build key) <gijs@pythonic.nl>  Mon, 02 Oct 2017 17:32:10 +0200
 

--- a/php-saml-ds/debian/control
+++ b/php-saml-ds/debian/control
@@ -2,6 +2,7 @@ Source: php-saml-ds
 Section: web
 Priority: extra
 Maintainer: François Kooman <fkooman@tuxed.net>
+Uploaders: Joost van Baal-Ilić <joostvb-eduvpn@ad1810.com>
 Build-Depends:
  debhelper (>= 9),
  phpab,

--- a/php-secookie/debian/changelog
+++ b/php-secookie/debian/changelog
@@ -1,6 +1,14 @@
+php-secookie (2.0.1-3) stable; urgency=medium
+
+  * debian/control: Add myself to Uploaders, similar to other packages in the
+    eduvpn suite.  This cleans up lintian source warnings:
+    "changelog-should-mention-nmu" and "source-nmu-has-incorrect-version-number".
+
+ -- Joost van Baal-Ilić <joostvb-eduvpn@ad1810.com>  Sun, 28 Oct 2018 10:39:33 +0100
+
 php-secookie (2.0.1-2) stable; urgency=medium
 
-   * debian/watch: upstream downloads moved from git.tuxed.net to
+  * debian/watch: upstream downloads moved from git.tuxed.net to
     software.tuxed.net.
   * debian/watch, debian/upstream/signing-key.asc: enabled pgpsigurlmangle option
     and ran "gpg --export --export-options export-minimal
@@ -30,10 +38,7 @@ php-secookie (2.0.0-2) stable; urgency=medium
 
 php-secookie (2.0.0-1) stable; urgency=medium
 
-  [ Gijs Molenaar ]
   * New upstream version 2.0.0
-
-  [ Gijs Molenaar (launchpad ppa build key) ]
 
  -- Gijs Molenaar (launchpad ppa build key) <gijs@pythonic.nl>  Mon, 02 Oct 2017 16:14:25 +0200
 

--- a/php-secookie/debian/control
+++ b/php-secookie/debian/control
@@ -2,6 +2,7 @@ Source: php-secookie
 Section: php
 Priority: optional
 Maintainer: François Kooman <fkooman@tuxed.net>
+Uploaders: Joost van Baal-Ilić <joostvb-eduvpn@ad1810.com>
 Build-Depends: 
  debhelper (>= 9), 
  phpunit, 

--- a/php-sqlite-migrate/debian/changelog
+++ b/php-sqlite-migrate/debian/changelog
@@ -1,3 +1,10 @@
+php-sqlite-migrate (0.1.1-4) stable; urgency=medium
+
+  * debian/control: Add myself to Uploaders, similar to other packages in the
+    eduvpn suite.
+
+ -- Joost van Baal-Ilić <joostvb-eduvpn@ad1810.com>  Sun, 28 Oct 2018 10:40:11 +0100
+
 php-sqlite-migrate (0.1.1-3) stable; urgency=medium
 
   * add missing php-sqlite3 dependency

--- a/php-sqlite-migrate/debian/control
+++ b/php-sqlite-migrate/debian/control
@@ -2,6 +2,7 @@ Source: php-sqlite-migrate
 Section: php
 Priority: optional
 Maintainer: François Kooman <fkooman@tuxed.net>
+Uploaders: Joost van Baal-Ilić <joostvb-eduvpn@ad1810.com>
 Build-Depends:
  debhelper (>= 9),
  phpunit,


### PR DESCRIPTION
Add myself to Uploaders, similar to other packages in the eduvpn suite.  This
cleans up lintian source warnings: "changelog-should-mention-nmu" and
"source-nmu-has-incorrect-version-number".