### PR TITLE
php-saml-ds, issue #11

### DIFF
--- a/php-saml-ds/debian/changelog
+++ b/php-saml-ds/debian/changelog
@@ -1,3 +1,9 @@
+php-saml-ds (1.0.12-4) stable; urgency=medium
+
+  * debian/copyright: refer to /usr/share/common-licenses/Apache-2.0, cleanup.
+
+ -- Joost van Baal-Ilić <joostvb-eduvpn@ad1810.com>  Thu, 01 Nov 2018 10:36:29 +0100
+
 php-saml-ds (1.0.12-3) stable; urgency=medium
 
   * debian/control: Add myself to Uploaders, similar to other packages in the

--- a/php-saml-ds/debian/copyright
+++ b/php-saml-ds/debian/copyright
@@ -1,28 +1,30 @@
-Format: http://dep.debian.net/deps/dep5
+Format: https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
 Upstream-Name: php-saml-ds
-Source: https://git.tuxed.net/fkooman/php-saml-ds
+Source: https://software.tuxed.net/php-saml-ds/download.html
 
 Files: *
-Copyright: François Kooman
+Copyright: 2017, 2018 François Kooman <fkooman@tuxed.net>
 License: apache2
 
 Files: debian/*
 Copyright: 2017 Gijs Molenaar <gijs@pythonic.nl>
 License: MIT
 
-
 License: apache2
- Licensed under the Apache License, Version 2.0 (the "License"); 
- you may not use this file except in compliance with the License. 
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
  You may obtain a copy of the License at
  .
  http://www.apache.org/licenses/LICENSE-2.0
  .
- Unless required by applicable law or agreed to in writing, software 
- distributed under the License is distributed on an "AS IS" BASIS, 
- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. 
- See the License for the specific language governing permissions and 
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
  limitations under the License.
+ .
+ On Debian systems, the complete text of the Apache version 2.0 license
+ can be found in "/usr/share/common-licenses/Apache-2.0".
 
 License: MIT
  Permission is hereby granted, free of charge, to any person obtaining a


### PR DESCRIPTION

debian/copyright: refer to /usr/share/common-licenses/Apache-2.0, cleanup.