### PR TITLE
work on Issue 17: version the pkg-php-tools build-depends

### DIFF
--- a/BaconQrCode/debian/changelog
+++ b/BaconQrCode/debian/changelog
@@ -1,6 +1,15 @@
+baconqrcode (1.0.3-5) stable; urgency=medium
+
+  * debian/control: make pkg-php-tools Build-Depends versioned, since we use
+    Composer package support: we need >= 1.7~.  NB: Debian jessie (current
+    oldstable) ships with pkg-php-tools 1.28.
+
+ -- Joost van Baal-Ilić <joostvb-eduvpn@ad1810.com>  Thu, 01 Nov 2018 16:07:23 +0100
+
 baconqrcode (1.0.3-4) stable; urgency=medium
 
-  * debian/control: Add myself to Uploaders, similar to other packages in the eduvpn suite.
+  * debian/control: Add myself to Uploaders, similar to other packages in the
+    eduvpn suite.
 
  -- Joost van Baal-Ilić <joostvb-eduvpn@ad1810.com>  Sun, 28 Oct 2018 10:30:11 +0100
 

--- a/BaconQrCode/debian/control
+++ b/BaconQrCode/debian/control
@@ -6,7 +6,7 @@ Uploaders: Joost van Baal-Ilić <joostvb-eduvpn@ad1810.com>
 Build-Depends: 
  debhelper (>= 9), 
  phpunit, 
- pkg-php-tools, 
+ pkg-php-tools (>= 1.7~), 
  phpab
 Standards-Version: 3.9.8
 Homepage: https://github.com/Bacon/BaconQrCode

--- a/Twig-extensions/debian/changelog
+++ b/Twig-extensions/debian/changelog
@@ -1,6 +1,15 @@
+twig-extensions (1.3.0-7) stable; urgency=medium
+
+  * debian/control: make pkg-php-tools Build-Depends versioned, since we use
+    Composer package support: we need >= 1.7~.  NB: Debian jessie (current
+    oldstable) ships with pkg-php-tools 1.28.
+
+ -- Joost van Baal-Ilić <joostvb-eduvpn@ad1810.com>  Thu, 01 Nov 2018 16:08:20 +0100
+
 twig-extensions (1.3.0-6) stable; urgency=medium
 
-  * debian/control: Add myself to Uploaders, similar to other packages in the eduvpn suite.
+  * debian/control: Add myself to Uploaders, similar to other packages in the
+    eduvpn suite.
 
  -- Joost van Baal-Ilić <joostvb-eduvpn@ad1810.com>  Sun, 28 Oct 2018 10:31:44 +0100
 

--- a/Twig-extensions/debian/control
+++ b/Twig-extensions/debian/control
@@ -7,7 +7,7 @@ Build-Depends:
  debhelper (>= 9), 
  phpunit, 
  phpab, 
- pkg-php-tools,
+ pkg-php-tools (>= 1.7~),
  php-symfony-translation, 
  php-symfony-phpunit-bridge,
  php-symfony-polyfill-mbstring, 

--- a/php-oauth2-server/debian/changelog
+++ b/php-oauth2-server/debian/changelog
@@ -1,3 +1,11 @@
+php-oauth2-server (3.0.2-4) stable; urgency=medium
+
+  * debian/control: make pkg-php-tools Build-Depends versioned, since we use
+    Composer package support: we need >= 1.7~.  NB: Debian jessie (current
+    oldstable) ships with pkg-php-tools 1.28.
+
+ -- Joost van Baal-Ilić <joostvb-eduvpn@ad1810.com>  Thu, 01 Nov 2018 16:02:18 +0100
+
 php-oauth2-server (3.0.2-3) stable; urgency=medium
 
   * debian/control: Add myself to Uploaders, similar to other packages in the

--- a/php-oauth2-server/debian/control
+++ b/php-oauth2-server/debian/control
@@ -5,7 +5,7 @@ Maintainer: François Kooman <fkooman@tuxed.net>
 Uploaders: Joost van Baal-Ilić <joostvb-eduvpn@ad1810.com>
 Build-Depends:
  debhelper (>= 9),
- pkg-php-tools,
+ pkg-php-tools (>= 1.7~),
  phpunit,
  phpab,
  php-common,

--- a/php-openvpn-connection-manager/debian/changelog
+++ b/php-openvpn-connection-manager/debian/changelog
@@ -1,3 +1,11 @@
+php-openvpn-connection-manager (1.0.2-5) stable; urgency=medium
+
+  * debian/control: make pkg-php-tools Build-Depends versioned, since we use
+    Composer package support: we need >= 1.7~.  NB: Debian jessie (current
+    oldstable) ships with pkg-php-tools 1.28.
+
+ -- Joost van Baal-Ilić <joostvb-eduvpn@ad1810.com>  Thu, 01 Nov 2018 16:03:58 +0100
+
 php-openvpn-connection-manager (1.0.2-4) stable; urgency=medium
 
   * debian/copyright: add missing full AGPL-3.0 text.  License debian/* under

--- a/php-openvpn-connection-manager/debian/control
+++ b/php-openvpn-connection-manager/debian/control
@@ -6,7 +6,7 @@ Uploaders: Joost van Baal-Ilić <joostvb-eduvpn@ad1810.com>
 Build-Depends:
  debhelper (>= 9),
  phpunit,
- pkg-php-tools,
+ pkg-php-tools (>= 1.7~),
  phpab,
  php-psr-log
 Standards-Version: 3.9.8

--- a/php-otp-verifier/debian/changelog
+++ b/php-otp-verifier/debian/changelog
@@ -1,3 +1,11 @@
+php-otp-verifier (0.2.1-3) stable; urgency=medium
+
+  * debian/control: make pkg-php-tools Build-Depends versioned, since we use
+    Composer package support: we need >= 1.7~.  NB: Debian jessie (current
+    oldstable) ships with pkg-php-tools 1.28.
+
+ -- Joost van Baal-Ilić <joostvb-eduvpn@ad1810.com>  Thu, 01 Nov 2018 16:04:39 +0100
+
 php-otp-verifier (0.2.1-2) stable; urgency=medium
 
   * debian/control: Add myself to Uploaders, similar to other packages in the

--- a/php-otp-verifier/debian/control
+++ b/php-otp-verifier/debian/control
@@ -6,7 +6,7 @@ Uploaders: Joost van Baal-Ilić <joostvb-eduvpn@ad1810.com>
 Build-Depends:
  debhelper (>= 9),
  phpunit,
- pkg-php-tools,
+ pkg-php-tools (>= 1.7~),
  phpab,
  php-sqlite3,
  php-constant-time

--- a/php-saml-ds/debian/changelog
+++ b/php-saml-ds/debian/changelog
@@ -1,3 +1,11 @@
+php-saml-ds (1.0.12-5) stable; urgency=medium
+
+  * debian/control: make pkg-php-tools Build-Depends versioned, since we use
+    Composer package support: we need >= 1.7~.  NB: Debian jessie (current
+    oldstable) ships with pkg-php-tools 1.28.
+
+ -- Joost van Baal-Ilić <joostvb-eduvpn@ad1810.com>  Thu, 01 Nov 2018 16:05:29 +0100
+
 php-saml-ds (1.0.12-4) stable; urgency=medium
 
   * debian/copyright: refer to /usr/share/common-licenses/Apache-2.0, cleanup.

--- a/php-saml-ds/debian/control
+++ b/php-saml-ds/debian/control
@@ -7,7 +7,7 @@ Build-Depends:
  debhelper (>= 9),
  phpab,
  phpunit,
- pkg-php-tools,
+ pkg-php-tools (>= 1.7~),
  dh-exec,
  php-fkooman-secookie,
  php-twig

--- a/php-secookie/debian/changelog
+++ b/php-secookie/debian/changelog
@@ -1,8 +1,17 @@
+php-secookie (2.0.1-4) stable; urgency=medium
+
+  * debian/control: make pkg-php-tools Build-Depends versioned, since we use
+    Composer package support: we need >= 1.7~.  NB: Debian jessie (current
+    oldstable) ships with pkg-php-tools 1.28.
+
+ -- Joost van Baal-Ilić <joostvb-eduvpn@ad1810.com>  Thu, 01 Nov 2018 16:06:10 +0100
+
 php-secookie (2.0.1-3) stable; urgency=medium
 
   * debian/control: Add myself to Uploaders, similar to other packages in the
     eduvpn suite.  This cleans up lintian source warnings:
-    "changelog-should-mention-nmu" and "source-nmu-has-incorrect-version-number".
+    "changelog-should-mention-nmu" and
+    "source-nmu-has-incorrect-version-number".
 
  -- Joost van Baal-Ilić <joostvb-eduvpn@ad1810.com>  Sun, 28 Oct 2018 10:39:33 +0100
 

--- a/php-secookie/debian/control
+++ b/php-secookie/debian/control
@@ -7,7 +7,7 @@ Build-Depends:
  debhelper (>= 9), 
  phpunit, 
  phpab, 
- pkg-php-tools
+ pkg-php-tools (>= 1.7~)
 Standards-Version: 3.9.8
 Homepage: https://git.tuxed.net/fkooman/php-secookie
 

--- a/php-sqlite-migrate/debian/changelog
+++ b/php-sqlite-migrate/debian/changelog
@@ -1,3 +1,11 @@
+php-sqlite-migrate (0.1.1-5) stable; urgency=medium
+
+  * debian/control: make pkg-php-tools Build-Depends versioned, since we use
+    Composer package support: we need >= 1.7~.  NB: Debian jessie (current
+    oldstable) ships with pkg-php-tools 1.28.
+
+ -- Joost van Baal-Ilić <joostvb-eduvpn@ad1810.com>  Thu, 01 Nov 2018 16:12:03 +0100
+
 php-sqlite-migrate (0.1.1-4) stable; urgency=medium
 
   * debian/control: Add myself to Uploaders, similar to other packages in the

--- a/php-sqlite-migrate/debian/control
+++ b/php-sqlite-migrate/debian/control
@@ -6,7 +6,7 @@ Uploaders: Joost van Baal-Ilić <joostvb-eduvpn@ad1810.com>
 Build-Depends:
  debhelper (>= 9),
  phpunit,
- pkg-php-tools,
+ pkg-php-tools (>= 1.7~),
  php-sqlite3,
  phpab
 Standards-Version: 3.9.8

--- a/vpn-lib-common/debian/changelog
+++ b/vpn-lib-common/debian/changelog
@@ -1,3 +1,11 @@
+vpn-lib-common (1.2.2-4) stable; urgency=medium
+
+  * debian/control: make pkg-php-tools Build-Depends versioned, since we use
+    Composer package support: we need >= 1.7~.  NB: Debian jessie (current
+    oldstable) ships with pkg-php-tools 1.28.
+
+ -- Joost van Baal-Ilić <joostvb-eduvpn@ad1810.com>  Thu, 01 Nov 2018 16:09:03 +0100
+
 vpn-lib-common (1.2.2-3) stable; urgency=medium
 
   * debian/copyright: upstream files are licensed using AGPL-3.0.  Reflect this

--- a/vpn-lib-common/debian/control
+++ b/vpn-lib-common/debian/control
@@ -6,7 +6,7 @@ Build-Depends:
  debhelper (>= 9),
  phpunit,
  phpab,
- pkg-php-tools,
+ pkg-php-tools (>= 1.7~),
  php-psr-log,
  php-fkooman-secookie,
  php-twig,

--- a/vpn-server-api/debian/changelog
+++ b/vpn-server-api/debian/changelog
@@ -1,3 +1,11 @@
+vpn-server-api (1.4.5-3) stable; urgency=medium
+
+  * debian/control: make pkg-php-tools Build-Depends versioned, since we use
+    Composer package support: we need >= 1.7~.  NB: Debian jessie (current
+    oldstable) ships with pkg-php-tools 1.28.
+
+ -- Joost van Baal-Ilić <joostvb-eduvpn@ad1810.com>  Thu, 01 Nov 2018 16:12:41 +0100
+
 vpn-server-api (1.4.5-2) stable; urgency=medium
 
   * debian/copyright: most upstream files are licensed using AGPL-3.0, some

--- a/vpn-server-api/debian/control
+++ b/vpn-server-api/debian/control
@@ -6,7 +6,7 @@ Build-Depends:
  debhelper (>= 9),
  dh-exec,
  phpab,
- pkg-php-tools,
+ pkg-php-tools (>= 1.7~),
  phpunit,
  php-fkooman-otp-verifier,
  php-fkooman-sqlite-migrate,

--- a/vpn-server-node/debian/changelog
+++ b/vpn-server-node/debian/changelog
@@ -1,3 +1,11 @@
+vpn-server-node (1.1.1-3) stable; urgency=medium
+
+  * debian/control: make pkg-php-tools Build-Depends versioned, since we use
+    Composer package support: we need >= 1.7~.  NB: Debian jessie (current
+    oldstable) ships with pkg-php-tools 1.28.
+
+ -- Joost van Baal-Ilić <joostvb-eduvpn@ad1810.com>  Thu, 01 Nov 2018 16:10:23 +0100
+
 vpn-server-node (1.1.1-2) stable; urgency=medium
 
   * debian/copyright: upstream files are licensed using AGPL-3.0.  Reflect this

--- a/vpn-server-node/debian/control
+++ b/vpn-server-node/debian/control
@@ -6,7 +6,7 @@ Build-Depends:
  debhelper (>= 9), 
  dh-exec, 
  phpunit, 
- pkg-php-tools, 
+ pkg-php-tools (>= 1.7~), 
  phpab,
  php-psr-log, 
  php-eduvpn-common, 

--- a/vpn-user-portal/debian/changelog
+++ b/vpn-user-portal/debian/changelog
@@ -1,3 +1,11 @@
+vpn-user-portal (1.8.3-3) stable; urgency=medium
+
+  * debian/control: make pkg-php-tools Build-Depends versioned, since we use
+    Composer package support: we need >= 1.7~.  NB: Debian jessie (current
+    oldstable) ships with pkg-php-tools 1.28.
+
+ -- Joost van Baal-Ilić <joostvb-eduvpn@ad1810.com>  Thu, 01 Nov 2018 16:11:23 +0100
+
 vpn-user-portal (1.8.3-2) stable; urgency=medium
 
   * debian/copyright: upstream files are licensed using AGPL-3.0.  Reflect this

--- a/vpn-user-portal/debian/control
+++ b/vpn-user-portal/debian/control
@@ -7,7 +7,7 @@ Build-Depends:
  dh-exec,
  phpab,
  phpunit,
- pkg-php-tools,
+ pkg-php-tools (>= 1.7~),
  php-common,
  php-fkooman-oauth2-client,
  php-eduvpn-common,


### PR DESCRIPTION
debian/control: make pkg-php-tools Build-Depends versioned, since we use
Composer package support: we need >= 1.7~.  NB: Debian jessie (current
oldstable) ships with pkg-php-tools 1.28.