### PR TITLE
Lintian vpn user portal

### DIFF
--- a/vpn-user-portal/debian/changelog
+++ b/vpn-user-portal/debian/changelog
@@ -7,7 +7,8 @@ vpn-user-portal (1.8.3-5) stable; urgency=medium
     '. /usr/share/debconf/confmodule'.
   * debian/control: Add myself to Uploaders, similar to other packages in the
     eduvpn suite.  This silences lintian source warnings:
-    "changelog-should-mention-nmu" and "source-nmu-has-incorrect-version-number".
+    "changelog-should-mention-nmu" and
+    "source-nmu-has-incorrect-version-number".
   * debian/lintian-overrides: added; with binary-without-manpage
     usr/bin/vpn-user-portal-*.  Those manpages are not planned to be written
     soonish.

--- a/vpn-user-portal/debian/changelog
+++ b/vpn-user-portal/debian/changelog
@@ -8,6 +8,9 @@ vpn-user-portal (1.8.3-5) stable; urgency=medium
   * debian/control: Add myself to Uploaders, similar to other packages in the
     eduvpn suite.  This silences lintian source warnings:
     "changelog-should-mention-nmu" and "source-nmu-has-incorrect-version-number".
+  * debian/lintian-overrides: added; with binary-without-manpage
+    usr/bin/vpn-user-portal-*.  Those manpages are not planned to be written
+    soonish.
 
  -- Joost van Baal-Ilić <joostvb-eduvpn@ad1810.com>  Wed, 07 Nov 2018 15:18:58 +0100
 

--- a/vpn-user-portal/debian/changelog
+++ b/vpn-user-portal/debian/changelog
@@ -12,6 +12,10 @@ vpn-user-portal (1.8.3-5) stable; urgency=medium
   * debian/lintian-overrides: added; with binary-without-manpage
     usr/bin/vpn-user-portal-*.  Those manpages are not planned to be written
     soonish.
+  * debian/{rules,postinst}: get rid of "override_dh_compress": we _do_ want
+    changelogs to get installed in compressed form.  Adjust postinst to deal
+    sane with compressed
+    /usr/share/doc/vpn-user-portal/config.php.example.gz .
 
  -- Joost van Baal-Ilić <joostvb-eduvpn@ad1810.com>  Wed, 07 Nov 2018 15:18:58 +0100
 
@@ -72,13 +76,11 @@ vpn-user-portal (1.8.0-2) stable; urgency=medium
 
 vpn-user-portal (1.8.0-1) stable; urgency=medium
 
-  * update to 1.8.0 
+  * update to 1.8.0
 
  -- François Kooman <fkooman@tuxed.net>  Tue, 04 Sep 2018 13:38:41 +0200
 
 vpn-user-portal (1.6.10-2) stable; urgency=medium
-
-  * UNRELEASED
 
   [ frozen-sky, in https://github.com/eduvpn/eduvpn-debian/pull/6 ]
   * Moved example configs to doc folders.
@@ -251,19 +253,13 @@ vpn-user-portal (1.0.10-1) stable; urgency=medium
 
 vpn-user-portal (1.0.8-1) stable; urgency=medium
 
-  [ Gijs Molenaar ]
   * New upstream version 1.0.8
-
-  [ Gijs Molenaar (launchpad ppa build key) ]
 
  -- Gijs Molenaar (launchpad ppa build key) <gijs@pythonic.nl>  Wed, 25 Oct 2017 17:28:55 +0200
 
 vpn-user-portal (1.0.7-1) stable; urgency=medium
 
-  [ Gijs Molenaar ]
   * New upstream version 1.0.7
-
-  [ Gijs Molenaar (launchpad ppa build key) ]
 
  -- Gijs Molenaar (launchpad ppa build key) <gijs@pythonic.nl>  Fri, 20 Oct 2017 10:09:54 +0200
 
@@ -294,11 +290,8 @@ vpn-user-portal (1.0.1-2) stable; urgency=medium
 
 vpn-user-portal (1.0.1-1) stable; urgency=medium
 
-  [ Gijs Molenaar ]
   * fix lintian warnings
   * New upstream version 1.0.1
-
-  [ Gijs Molenaar (launchpad ppa build key) ]
 
  -- Gijs Molenaar (launchpad ppa build key) <gijs@pythonic.nl>  Thu, 31 Aug 2017 11:50:44 +0200
 

--- a/vpn-user-portal/debian/changelog
+++ b/vpn-user-portal/debian/changelog
@@ -2,7 +2,8 @@ vpn-user-portal (1.8.3-5) stable; urgency=medium
 
   * debian/docs: remove explicit CHANGES.md since implicitly dealt with by
     dh_installchangelogs.
-  * debian/preinst: add missing debhelper token, remove unused
+  * debian/preinst: add missing debhelper token.
+  * debian/{postrm,postinst,preinst}: remove unused
     '. /usr/share/debconf/confmodule'.
 
  -- Joost van Baal-Ilić <joostvb-eduvpn@ad1810.com>  Wed, 07 Nov 2018 15:18:58 +0100

--- a/vpn-user-portal/debian/changelog
+++ b/vpn-user-portal/debian/changelog
@@ -5,6 +5,9 @@ vpn-user-portal (1.8.3-5) stable; urgency=medium
   * debian/preinst: add missing debhelper token.
   * debian/{postrm,postinst,preinst}: remove unused
     '. /usr/share/debconf/confmodule'.
+  * debian/control: Add myself to Uploaders, similar to other packages in the
+    eduvpn suite.  This silences lintian source warnings:
+    "changelog-should-mention-nmu" and "source-nmu-has-incorrect-version-number".
 
  -- Joost van Baal-Ilić <joostvb-eduvpn@ad1810.com>  Wed, 07 Nov 2018 15:18:58 +0100
 

--- a/vpn-user-portal/debian/changelog
+++ b/vpn-user-portal/debian/changelog
@@ -1,3 +1,10 @@
+vpn-user-portal (1.8.3-5) stable; urgency=medium
+
+  * debian/docs: remove explicit CHANGES.md since implicitly dealt with by
+    dh_installchangelogs.
+
+ -- Joost van Baal-Ilić <joostvb-eduvpn@ad1810.com>  Wed, 07 Nov 2018 15:18:58 +0100
+
 vpn-user-portal (1.8.3-4) stable; urgency=medium
 
   * remove redundant dependencies

--- a/vpn-user-portal/debian/changelog
+++ b/vpn-user-portal/debian/changelog
@@ -2,6 +2,8 @@ vpn-user-portal (1.8.3-5) stable; urgency=medium
 
   * debian/docs: remove explicit CHANGES.md since implicitly dealt with by
     dh_installchangelogs.
+  * debian/preinst: add missing debhelper token, remove unused
+    '. /usr/share/debconf/confmodule'.
 
  -- Joost van Baal-Ilić <joostvb-eduvpn@ad1810.com>  Wed, 07 Nov 2018 15:18:58 +0100
 

--- a/vpn-user-portal/debian/control
+++ b/vpn-user-portal/debian/control
@@ -2,6 +2,7 @@ Source: vpn-user-portal
 Section: web
 Priority: optional
 Maintainer: François Kooman <fkooman@tuxed.net>
+Uploaders: Joost van Baal-Ilić <joostvb-eduvpn@ad1810.com>
 Build-Depends:
  debhelper (>= 9),
  dh-exec,

--- a/vpn-user-portal/debian/docs
+++ b/vpn-user-portal/debian/docs
@@ -1,4 +1,3 @@
-README.md 
-CHANGES.md
+README.md
 composer.json
 config/config.php.example

--- a/vpn-user-portal/debian/lintian-overrides
+++ b/vpn-user-portal/debian/lintian-overrides
@@ -1,0 +1,5 @@
+vpn-user-portal: binary-without-manpage usr/bin/vpn-user-portal-add-user
+vpn-user-portal: binary-without-manpage usr/bin/vpn-user-portal-foreign-key-list-fetcher
+vpn-user-portal: binary-without-manpage usr/bin/vpn-user-portal-generate-voucher
+vpn-user-portal: binary-without-manpage usr/bin/vpn-user-portal-init
+vpn-user-portal: binary-without-manpage usr/bin/vpn-user-portal-show-public-key

--- a/vpn-user-portal/debian/postinst
+++ b/vpn-user-portal/debian/postinst
@@ -5,10 +5,6 @@
 
 set -e
 
-if [ -f /usr/share/debconf/confmodule ]; then
-        . /usr/share/debconf/confmodule
-fi
-
 case "$1" in
     configure)
         chown -R www-data:www-data /var/lib/vpn-user-portal

--- a/vpn-user-portal/debian/postinst
+++ b/vpn-user-portal/debian/postinst
@@ -29,8 +29,13 @@ case "$1" in
 		if [ ! -d /etc/vpn-user-portal/default ]; then
 			echo "New installation, creating default configuration"
 			install -d -m 755 /etc/vpn-user-portal/default
-			install -m 644 /usr/share/doc/vpn-user-portal/config.php.example \
+			if [ -f /usr/share/doc/vpn-user-portal/config.php.example ]; then
+				install -m 644 /usr/share/doc/vpn-user-portal/config.php.example \
 				       /etc/vpn-user-portal/default/config.php
+			elif [ -f /usr/share/doc/vpn-user-portal/config.php.example.gz ]; then
+				zcat /usr/share/doc/vpn-user-portal/config.php.example.gz \
+				       >/etc/vpn-user-portal/default/config.php
+			fi
 		else
 			echo "New installation, but existing default configuration found. Not updating"
 		fi

--- a/vpn-user-portal/debian/postrm
+++ b/vpn-user-portal/debian/postrm
@@ -5,10 +5,6 @@
 
 set -e
 
-if [ -f /usr/share/debconf/confmodule ]; then
-        . /usr/share/debconf/confmodule
-fi
-
 case "$1" in
     failed-upgrade|abort-install|abort-upgrade|disappear|remove)
     ;;
@@ -17,7 +13,7 @@ case "$1" in
         echo "removing old template cache..."
         rm -rf /var/lib/vpn-user-portal/*/tpl/*
     ;;
-    
+
     purge)
         rm -rf /var/lib/vpn-user-portal
     ;;

--- a/vpn-user-portal/debian/preinst
+++ b/vpn-user-portal/debian/preinst
@@ -5,17 +5,11 @@
 
 set -e
 
-if [ -f /usr/share/debconf/confmodule ]; then
-        . /usr/share/debconf/confmodule
-fi
-
 case "$1" in
     upgrade)
-	# Mark upgrade    
+	# Mark upgrade
         touch /etc/vpn-user-portal/.upgrade
     ;;
-    
 esac
 
-
-exit 0
+#DEBHELPER#

--- a/vpn-user-portal/debian/rules
+++ b/vpn-user-portal/debian/rules
@@ -20,8 +20,5 @@ override_dh_auto_test:
 	echo "require_once 'src/autoload.php';" >> tests/autoload.php
 	phpunit --bootstrap=tests/autoload.php
 
-# Be sure not to compress
-override_dh_compress:
-
 %:
 	dh $@ --with phpcomposer


### PR DESCRIPTION
Fix 12 out of 14 lintian errors/warnings.  The 2 which are still open:

E: vpn-user-portal: description-is-pkg-name VPN User Portal
E: vpn-user-portal: extended-description-is-empty

.