### PR TITLE
more lintian fixes

### DIFF
--- a/vpn-admin-portal/debian/changelog
+++ b/vpn-admin-portal/debian/changelog
@@ -1,3 +1,12 @@
+vpn-admin-portal (1.7.2-4) stable; urgency=medium
+
+  * debian/control: Add myself to Uploaders, similar to other packages in the
+    eduVPN suite.  This silences lintian source warnings
+    "changelog-should-mention-nmu" and
+    "source-nmu-has-incorrect-version-number".
+
+ -- Joost van Baal-Ilić <joostvb-eduvpn@ad1810.com>  Wed, 07 Nov 2018 17:00:49 +0100
+
 vpn-admin-portal (1.7.2-3) stable; urgency=medium
 
   * remove php-spl dependency, does not exist on Debian

--- a/vpn-admin-portal/debian/control
+++ b/vpn-admin-portal/debian/control
@@ -2,6 +2,7 @@ Source: vpn-admin-portal
 Section: web
 Priority: optional
 Maintainer: François Kooman <fkooman@tuxed.net>
+Uploaders: Joost van Baal-Ilić <joostvb-eduvpn@ad1810.com>
 Build-Depends: 
  debhelper (>= 9), 
  dh-exec, 

--- a/vpn-lib-common/debian/changelog
+++ b/vpn-lib-common/debian/changelog
@@ -1,6 +1,15 @@
+vpn-lib-common (1.2.2-6) stable; urgency=medium
+
+  * debian/control: Add myself to Uploaders, similar to other packages in the
+    eduVPN suite.  This silences lintian source warnings
+    "changelog-should-mention-nmu" and
+    "source-nmu-has-incorrect-version-number".
+
+ -- Joost van Baal-Ilić <joostvb-eduvpn@ad1810.com>  Wed, 07 Nov 2018 17:02:37 +0100
+
 vpn-lib-common (1.2.2-5) stable; urgency=medium
 
-  * remove redundant dependencies 
+  * remove redundant dependencies
 
  -- François Kooman <fkooman@tuxed.net>  Fri, 02 Nov 2018 18:55:32 +0100
 

--- a/vpn-lib-common/debian/control
+++ b/vpn-lib-common/debian/control
@@ -2,6 +2,7 @@ Source: vpn-lib-common
 Section: php
 Priority: optional
 Maintainer: François Kooman <fkooman@tuxed.net>
+Uploaders: Joost van Baal-Ilić <joostvb-eduvpn@ad1810.com>
 Build-Depends: 
  debhelper (>= 9),
  phpunit,

--- a/vpn-server-api/debian/changelog
+++ b/vpn-server-api/debian/changelog
@@ -1,3 +1,12 @@
+vpn-server-api (1.4.5-5) stable; urgency=medium
+
+  * debian/control: Add myself to Uploaders, similar to other packages in the
+    eduVPN suite.  This silences lintian source warnings
+    "changelog-should-mention-nmu" and
+    "source-nmu-has-incorrect-version-number".
+
+ -- Joost van Baal-Ilić <joostvb-eduvpn@ad1810.com>  Wed, 07 Nov 2018 17:03:40 +0100
+
 vpn-server-api (1.4.5-4) stable; urgency=medium
 
   * remove redundant dependencies

--- a/vpn-server-api/debian/control
+++ b/vpn-server-api/debian/control
@@ -2,6 +2,7 @@ Source: vpn-server-api
 Section: web
 Priority: optional
 Maintainer: François Kooman <fkooman@tuxed.net>
+Uploaders: Joost van Baal-Ilić <joostvb-eduvpn@ad1810.com>
 Build-Depends:
  debhelper (>= 9),
  dh-exec,

--- a/vpn-server-node/debian/changelog
+++ b/vpn-server-node/debian/changelog
@@ -1,3 +1,12 @@
+vpn-server-node (1.1.1-5) stable; urgency=medium
+
+  * debian/control: Add myself to Uploaders, similar to other packages in the
+    eduVPN suite.  This silences lintian source warnings
+    "changelog-should-mention-nmu" and
+    "source-nmu-has-incorrect-version-number".
+
+ -- Joost van Baal-Ilić <joostvb-eduvpn@ad1810.com>  Wed, 07 Nov 2018 17:03:40 +0100
+
 vpn-server-node (1.1.1-4.1) stable; urgency=medium
 
   * remove redundant dependencies

--- a/vpn-server-node/debian/control
+++ b/vpn-server-node/debian/control
@@ -2,6 +2,7 @@ Source: vpn-server-node
 Section: php
 Priority: optional
 Maintainer: François Kooman <fkooman@tuxed.net>
+Uploaders: Joost van Baal-Ilić <joostvb-eduvpn@ad1810.com>
 Build-Depends: 
  debhelper (>= 9), 
  dh-exec, 


### PR DESCRIPTION

debian/control: Add myself to Uploaders, similar to other packages in the
eduVPN suite.  This silences lintian source warnings
"changelog-should-mention-nmu" and "source-nmu-has-incorrect-version-number".