### PR TITLE
Lintian vpn server api

### DIFF
--- a/vpn-server-api/debian/changelog
+++ b/vpn-server-api/debian/changelog
@@ -5,6 +5,9 @@ vpn-server-api (1.4.6-2) stable; urgency=medium
   * debian/preinst: add missing debhelper token.
   * debian/{postrm,postinst,preinst}: remove unused
     '. /usr/share/debconf/confmodule'.
+  * debian/lintian-overrides: added; with binary-without-manpage
+    usr/bin/vpn-server-api-* .  These manpages are not planned to be written
+    soonish.
 
  -- Joost van Baal-Ilić <joostvb-eduvpn@ad1810.com>  Thu, 15 Nov 2018 09:16:02 +0100
 

--- a/vpn-server-api/debian/changelog
+++ b/vpn-server-api/debian/changelog
@@ -1,3 +1,9 @@
+vpn-server-api (1.4.6-2) stable; urgency=medium
+
+  * debian/preinst: add missing debhelper token.
+
+ -- Joost van Baal-Ilić <joostvb-eduvpn@ad1810.com>  Thu, 15 Nov 2018 09:16:02 +0100
+
 vpn-server-api (1.4.6-1) stable; urgency=medium
 
   * update to 1.4.6

--- a/vpn-server-api/debian/changelog
+++ b/vpn-server-api/debian/changelog
@@ -1,6 +1,8 @@
 vpn-server-api (1.4.6-2) stable; urgency=medium
 
   * debian/preinst: add missing debhelper token.
+  * debian/{postrm,postinst,preinst}: remove unused
+    '. /usr/share/debconf/confmodule'.
 
  -- Joost van Baal-Ilić <joostvb-eduvpn@ad1810.com>  Thu, 15 Nov 2018 09:16:02 +0100
 

--- a/vpn-server-api/debian/changelog
+++ b/vpn-server-api/debian/changelog
@@ -11,6 +11,9 @@ vpn-server-api (1.4.6-2) stable; urgency=medium
   * debian/{rules,postinst}: get rid of "override_dh_compress": we _do_ want
     changelogs to get installed in compressed form.  Adjust postinst to deal
     sane with compressed /usr/share/doc/vpn-server-api/config.php.example.gz .
+  * debian/install: no longer install easy-rsa documentation under
+    usr/share/vpn-server-api/easy-rsa/, but under
+    usr/share/doc/vpn-server-api/easy-rsa/ .
 
  -- Joost van Baal-Ilić <joostvb-eduvpn@ad1810.com>  Thu, 15 Nov 2018 09:16:02 +0100
 

--- a/vpn-server-api/debian/changelog
+++ b/vpn-server-api/debian/changelog
@@ -8,6 +8,9 @@ vpn-server-api (1.4.6-2) stable; urgency=medium
   * debian/lintian-overrides: added; with binary-without-manpage
     usr/bin/vpn-server-api-* .  These manpages are not planned to be written
     soonish.
+  * debian/{rules,postinst}: get rid of "override_dh_compress": we _do_ want
+    changelogs to get installed in compressed form.  Adjust postinst to deal
+    sane with compressed /usr/share/doc/vpn-server-api/config.php.example.gz .
 
  -- Joost van Baal-Ilić <joostvb-eduvpn@ad1810.com>  Thu, 15 Nov 2018 09:16:02 +0100
 

--- a/vpn-server-api/debian/changelog
+++ b/vpn-server-api/debian/changelog
@@ -1,5 +1,7 @@
 vpn-server-api (1.4.6-2) stable; urgency=medium
 
+  * debian/docs: remove explicit CHANGES.md since implicitly dealt with by
+    dh_installchangelogs.
   * debian/preinst: add missing debhelper token.
   * debian/{postrm,postinst,preinst}: remove unused
     '. /usr/share/debconf/confmodule'.

--- a/vpn-server-api/debian/docs
+++ b/vpn-server-api/debian/docs
@@ -1,4 +1,3 @@
-README.md 
-CHANGES.md
+README.md
 composer.json
 config/config.php.example

--- a/vpn-server-api/debian/install
+++ b/vpn-server-api/debian/install
@@ -5,8 +5,16 @@ config/config.php.example => /usr/share/doc/vpn-server-api/config.php.example
 
 src/* /usr/share/php/SURFnet/VPN/Server/
 web /usr/share/vpn-server-api/
-easy-rsa /usr/share/vpn-server-api/
 schema /usr/share/vpn-server-api/
+
+easy-rsa/ChangeLog /usr/share/doc/vpn-server-api/easy-rsa/
+easy-rsa/README.quickstart.md /usr/share/doc/vpn-server-api/easy-rsa/
+easy-rsa/doc /usr/share/doc/vpn-server-api/easy-rsa/
+easy-rsa/vars.example /usr/share/doc/vpn-server-api/easy-rsa/
+
+easy-rsa/easyrsa /usr/share/vpn-server-api/easy-rsa/
+easy-rsa/openssl-1.0.cnf /usr/share/vpn-server-api/easy-rsa/
+easy-rsa/x509-types /usr/share/vpn-server-api/easy-rsa/
 
 bin/housekeeping.php => /usr/bin/vpn-server-api-housekeeping
 bin/init.php => /usr/bin/vpn-server-api-init

--- a/vpn-server-api/debian/lintian-overrides
+++ b/vpn-server-api/debian/lintian-overrides
@@ -1,0 +1,8 @@
+vpn-server-api: binary-without-manpage usr/bin/vpn-server-api-housekeeping
+vpn-server-api: binary-without-manpage usr/bin/vpn-server-api-init
+vpn-server-api: binary-without-manpage usr/bin/vpn-server-api-show-instance-info
+vpn-server-api: binary-without-manpage usr/bin/vpn-server-api-stats
+vpn-server-api: binary-without-manpage usr/bin/vpn-server-api-status
+vpn-server-api: binary-without-manpage usr/bin/vpn-server-api-update-api-secrets
+vpn-server-api: binary-without-manpage usr/bin/vpn-server-api-update-ip
+

--- a/vpn-server-api/debian/postinst
+++ b/vpn-server-api/debian/postinst
@@ -31,7 +31,7 @@ case "$1" in
 			if [ -f /usr/share/doc/vpn-server-api/config.php.example ]; then
 				install -m 644 /usr/share/doc/vpn-server-api/config.php.example \
 				  /etc/vpn-server-api/default/config.php
-			elsif [ -f /usr/share/doc/vpn-server-api/config.php.example.gz ]; then
+			elif [ -f /usr/share/doc/vpn-server-api/config.php.example.gz ]; then
 				zcat /usr/share/doc/vpn-server-api/config.php.example.gz \
 				  >/etc/vpn-server-api/default/config.php
 			fi

--- a/vpn-server-api/debian/postinst
+++ b/vpn-server-api/debian/postinst
@@ -5,10 +5,6 @@
 
 set -e
 
-if [ -f /usr/share/debconf/confmodule ]; then
-        . /usr/share/debconf/confmodule
-fi
-
 case "$1" in
     configure)
         chown www-data:www-data /var/lib/vpn-server-api

--- a/vpn-server-api/debian/postinst
+++ b/vpn-server-api/debian/postinst
@@ -28,8 +28,13 @@ case "$1" in
 		if [ ! -d /etc/vpn-server-api/default ]; then
 			echo "New installation, creating default configuration"
 			install -d -m 755 /etc/vpn-server-api/default
-			install -m 644 /usr/share/doc/vpn-server-api/config.php.example \
-				       /etc/vpn-server-api/default/config.php
+			if [ -f /usr/share/doc/vpn-server-api/config.php.example ]; then
+				install -m 644 /usr/share/doc/vpn-server-api/config.php.example \
+				  /etc/vpn-server-api/default/config.php
+			elsif [ -f /usr/share/doc/vpn-server-api/config.php.example.gz ]; then
+				zcat /usr/share/doc/vpn-server-api/config.php.example.gz \
+				  >/etc/vpn-server-api/default/config.php
+			fi
 		else
 			echo "New installation, but existing default configuration found. Not updating"
 		fi

--- a/vpn-server-api/debian/postrm
+++ b/vpn-server-api/debian/postrm
@@ -5,14 +5,9 @@
 
 set -e
 
-if [ -f /usr/share/debconf/confmodule ]; then
-        . /usr/share/debconf/confmodule
-fi
-
 case "$1" in
     upgrade|failed-upgrade|abort-install|abort-upgrade|disappear|remove)
     ;;
-    
     purge)
         rm -rf /var/lib/vpn-server-api
     ;;
@@ -23,7 +18,3 @@ case "$1" in
 esac
 
 #DEBHELPER#
-
-exit 0
-
-

--- a/vpn-server-api/debian/preinst
+++ b/vpn-server-api/debian/preinst
@@ -5,10 +5,6 @@
 
 set -e
 
-if [ -f /usr/share/debconf/confmodule ]; then
-        . /usr/share/debconf/confmodule
-fi
-
 case "$1" in
     upgrade)
 	# Mark upgrade

--- a/vpn-server-api/debian/preinst
+++ b/vpn-server-api/debian/preinst
@@ -11,11 +11,9 @@ fi
 
 case "$1" in
     upgrade)
-	# Mark upgrade    
+	# Mark upgrade
         touch /etc/vpn-server-api/.upgrade
     ;;
-    
 esac
 
-
-exit 0
+#DEBHELPER#

--- a/vpn-server-api/debian/rules
+++ b/vpn-server-api/debian/rules
@@ -23,8 +23,5 @@ override_dh_auto_test:
 	echo "require_once 'src/autoload.php';" >> tests/autoload.php
 	phpunit --bootstrap=tests/autoload.php
 
-# Be sure not to compress
-override_dh_compress:
-
 %:
 	dh $@ --with phpcomposer


### PR DESCRIPTION
This fixes  15 from 18 lintian issues.  3 still open:

W: vpn-server-api source: missing-license-paragraph-in-dep5-copyright glp-2+ (paragraph at line 9)
E: vpn-server-api: description-is-pkg-name VPN Server API
E: vpn-server-api: extended-description-is-empty

I'll fix those in a later PR. could you please inspect and, if ok, merge this one?
