### PR TITLE
lintian vpn server api

### DIFF
--- a/vpn-server-api/debian/changelog
+++ b/vpn-server-api/debian/changelog
@@ -1,3 +1,10 @@
+vpn-server-api (1.4.6-3) stable; urgency=medium
+
+  * debian/control: enhance description inspired by current upstream
+    https://github.com/eduvpn/vpn-server-api/blob/master/README.md .
+
+ -- Joost van Baal-Ilić <joostvb-eduvpn@ad1810.com>  Sat, 17 Nov 2018 09:46:59 +0100
+
 vpn-server-api (1.4.6-2) stable; urgency=medium
 
   * debian/docs: remove explicit CHANGES.md since implicitly dealt with by

--- a/vpn-server-api/debian/control
+++ b/vpn-server-api/debian/control
@@ -38,4 +38,10 @@ Depends:
  php-constant-time,
  openvpn
 Suggests: ${phpcomposer:Debian-suggest}
-Description: VPN Server API
+Description: VPN Server API for Let's Connect!
+ This package provides the server API of the Let's Connect! software. It is
+ used by both vpn-admin-portal and vpn-user-portal. It contains the Easy-RSA
+ X.509 PKI which supplies a CA and a database containing information about the
+ users and links issued certificates to users.  It furthermore ships some
+ housekeeping cronjobs as well as a configuration snippet for easy
+ integration with the Apache webserver.


### PR DESCRIPTION
debian/control: enhance description inspired by current upstream https://github.com/eduvpn/vpn-server-api/blob/master/README.md .

2 lintian errors fixed.  one warning stil open:

W: vpn-server-api source: missing-license-paragraph-in-dep5-copyright glp-2+ (paragraph at line 9)

please merge