### PR TITLE
debian/control: Depends: replace ${phpcomposer:Debian-require}, from …

### DIFF
--- a/php-jwt/debian/changelog
+++ b/php-jwt/debian/changelog
@@ -1,3 +1,14 @@
+php-jwt (1.0.1-4) stable; urgency=medium
+
+  * debian/control: Depends: replace ${phpcomposer:Debian-require}, from
+    Depends (expands to php-json, php-paragonie-constant-time-encoding,
+    php-paragonie-random-compat (>= 1), php-paragonie-sodium-compat (>= 1),
+    php-paragonie-sodium-compat (<< 2~~) as found in upstream composer.json)
+    with bare explicit php-json.  The paragonie packages are not shipped with
+    Debian buster, and are not needed on systems running PHP >= 7.2.
+
+ -- Joost van Baal-Ilić <joostvb-eduvpn@ad1810.com>  Thu, 19 Sep 2019 11:18:22 +0200
+
 php-jwt (1.0.1-3) stable; urgency=medium
 
   * debian/control: Depends: replace explicit php-json by

--- a/php-jwt/debian/control
+++ b/php-jwt/debian/control
@@ -17,7 +17,7 @@ Package: php-fkooman-jwt
 Architecture: all
 Depends:
  ${misc:Depends},
- ${phpcomposer:Debian-require},
+ php-json,
  php-constant-time (>= 2.2.0~)
 Suggests: ${phpcomposer:Debian-suggest}
 Description: JWT Library.


### PR DESCRIPTION
…Depends (expands to php-json, php-paragonie-constant-time-encoding, php-paragonie-random-compat (>= 1), php-paragonie-sodium-compat (>= 1), php-paragonie-sodium-compat (<< 2~~) as found in upstream composer.json) with bare explicit php-json.  The paragonie packages are not shipped with Debian buster, and are not needed on systems running PHP >= 7.2.